### PR TITLE
Change accept header value to Firefox default value for images

### DIFF
--- a/background.js
+++ b/background.js
@@ -3,7 +3,7 @@ function modifyAcceptHeader(details) {
     if (header.name.toLowerCase() === 'accept') {
       return {
         name: header.name,
-        value: 'image/*'
+        value: 'image/avif,image/webp,*/*'
       };
     }
     return header;


### PR DESCRIPTION
Rather than a generic "image/*", use the current value that Firefox does for images. This means that AVIF and WEBP versions of images, which are smaller than jpeg or png, will be served.

Value retrieved from this webpage:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Content_negotiation/List_of_default_Accept_values